### PR TITLE
better copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,20 +32,21 @@
           <h2>To get <span class="zapped">Zapped</span> you can copy</h2>
           <div class="codeblock" onclick="copy()">
             sh <(curl -s https://raw<wbr />.githubusercontent<wbr />.com/zap-zsh/zap/master/install.sh)
+            <div style="display: none" id="test"><p>Copied!</p></div>
           </div>
-          <div style="display: none" id="test">Copied!</div>
         </div>
       </div>
     </main>
     <script>
       function copy() {
         navigator.clipboard.writeText(
-          'sh <(curl -s https://raw.githubusercontent.com/zap-zsh/zap/master/install.sh)'
-        )
-        document.getElementById('test').style.display = 'block'
-        setTimeout(function () {
-          document.getElementById('test').style.display = 'none'
-        }, 2000)
+            "sh <(curl -s https://raw.githubusercontent.com/zap-zsh/zap/master/install.sh)"
+          ).then(() => {
+            document.getElementById("test").style.display = "flex";
+            setTimeout(function () {
+              document.getElementById("test").style.display = "none";
+            }, 2000);
+          });
       }
     </script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,7 @@ main {
   align-items: center;
   justify-content: center;
   flex-direction: column;
+  padding-inline: .5rem;
 
   background-color: var(--bg-alt);
 
@@ -166,11 +167,26 @@ main {
   color: var(--yellow-alt);
   padding: 12px;
   border-radius: var(--border);
+  position: relative;
+  overflow: hidden;
 }
 
 .codeblock:hover {
   background-color: #3f3f42;
   color: #e6e3dc;
+}
+
+#test {
+  position: absolute;
+  inset: 0;
+  background-color: #3f3f42;
+  color: #8bf244;
+  pointer-events: none;
+  padding: 12px;
+}
+
+#test > p {
+  margin: auto;
 }
 
 @media screen and (max-width: 300px) {
@@ -180,6 +196,6 @@ main {
     max-width: 100%;
   }
   .codeblock {
-    padding: 0px;
+    padding-inline: 0px;
   }
 }


### PR DESCRIPTION
I added `.then` to the `clipboard.writeText()` method, so it'll only show the "Copied!" message if it succeeds, and it'll do nothing if it failed, for a reference: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText

+ the "Copied!" message causing the container height to increase, 

https://user-images.githubusercontent.com/69465962/201053023-9c5f8c98-7b42-4918-8cca-0e057034f35d.mp4

so I made some changes to the copied message ui, so it's simpler and cleaner

https://user-images.githubusercontent.com/69465962/201052747-4b597246-6781-436a-980f-cf17e87be78a.mp4