### PR TITLE
fix(#8): optional multiple whitespace to match the url

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 import { Octokit } from "https://esm.sh/@octokit/rest";
 
-const re = /-\s\[.+\]\(https:\/\/github\.com\/(\S+)\)\s-/;
+const re = /-\s+\[.+\]\(https:\/\/github\.com\/(\S+)\)\s-/;
 
 async function buildRepoSection(owner, repo, path) {
   await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`)
@@ -66,7 +66,7 @@ codeBlock.addEventListener("click", copy);
 function copy() {
   navigator.clipboard
     .writeText(
-      "zsh <(curl -s https://raw.githubusercontent.com/zap-zsh/zap/master/install.zsh) --branch release-v1"
+      "zsh <(curl -s https://raw.githubusercontent.com/zap-zsh/zap/master/install.zsh) --branch release-v1",
     )
     .then(() => {
       document.getElementById("test").style.display = "flex";


### PR DESCRIPTION
before the regex was not matching because of the leading space before the square brackets, I fixed it by adding an optional multi space character to accurately match links that have a leading whitespace 